### PR TITLE
Return error when package not found

### DIFF
--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -136,6 +136,11 @@ func defSymbolDescriptor(pkg *packages.Package, packageCache *source.GlobalCache
 	defPkg, _ := pkg.Imports[def.ImportPath]
 	if defPkg == nil {
 		defPkg, err = findPackage(packageCache, filepath.Dir(pkg.GoFiles[0]), def.ImportPath)
+
+		if defPkg == nil {
+			return nil, fmt.Errorf("cannot find package for %s in %s", pkg.GoFiles[0], def.ImportPath)
+		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes a panic when looking up a definition of a symbol in a main
package.

This is missing tests, and likely doesn't understand the full scope of the problem. Suggestions strongly welcomed.