### PR TITLE
Do not return error when signatureHelp is called with non-callable

### DIFF
--- a/langserver/internal/source/signature_help.go
+++ b/langserver/internal/source/signature_help.go
@@ -49,7 +49,7 @@ func SignatureHelp(ctx context.Context, f File, pos token.Pos, builtinPkg *packa
 		}
 	}
 	if callExpr == nil || callExpr.Fun == nil {
-		return nil, fmt.Errorf("cannot find an enclosing function")
+		return nil, nil
 	}
 
 	// Get the type information for the function corresponding to the call expression.

--- a/langserver/lsp_signature_test.go
+++ b/langserver/lsp_signature_test.go
@@ -23,6 +23,7 @@ func TestSignature(t *testing.T) {
 	t.Run("signature help", func(t *testing.T) {
 		test(t, map[string]string{
 			"signature/b.go:1:28": "B() 0",
+			"signature/b.go:1:29": " 0",
 			"signature/b.go:1:33": "A(foo int, bar func(baz int) int) 0",
 			"signature/b.go:1:40": "A(foo int, bar func(baz int) int) 1",
 			"signature/b.go:1:46": "A(foo int, bar func(baz int) int) 0",

--- a/langserver/signature.go
+++ b/langserver/signature.go
@@ -19,6 +19,10 @@ func (h *LangHandler) handleTextDocumentSignatureHelp(ctx context.Context, conn 
 		return nil, err
 	}
 
+	if info == nil {
+		return nil, nil
+	}
+
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}


### PR DESCRIPTION
This PR fixes https://github.com/saibing/bingo/issues/41.