### PR TITLE
look for module roots in directories above the provided rootUri

### DIFF
--- a/langserver/internal/cache/project.go
+++ b/langserver/internal/cache/project.go
@@ -161,6 +161,28 @@ func (p *Project) findGoModFiles() ([]string, error) {
 	}
 
 	err := p.walkDir(p.rootDir, 0, walkFunc)
+
+	if len(gomodList) == 0 {
+		// {"/", "path", "to", "rootDir"}
+		var segs = append(
+			[]string{string(filepath.Separator)},
+			strings.Split(p.rootDir, string(filepath.Separator))...,
+		)
+
+		for i := len(segs) - 1; i > 0; i-- {
+			var (
+				newRoot = filepath.Join(segs[0:i]...)
+				newMod  = filepath.Join(newRoot, gomod)
+			)
+			info, err := os.Stat(newMod)
+			if err == nil && !info.IsDir() {
+				p.rootDir = newRoot
+				gomodList = append([]string{newMod}, gomodList...)
+				break
+			}
+		}
+	}
+
 	return gomodList, err
 }
 


### PR DESCRIPTION
Don't rely on the client to figure out the correct go module root and also look got `go.mod` files in parent directories of the provided `rootUri`. 

I'm using [eglot](https://github.com/joaotavora/eglot) and I encountered a bug with a project layout like this: 

```
my-module/go.mod
my-module/testing/
my-module/testing/lib/
my-module/testing/lib/my_source_file.go
```

where I was editing `my_source_file.go` and eglot passed down `my-module/testing/lib/` as the `rootUri`. This PR is also the question: is the client supposed to figure out the nearest enclosing go module for the file, or is this indeed a job for the language server? 

If so, I could improve this code. Atm. it only looks for module roots up the hierarchy if it doesn't find any by the former mechanism. 

great software. I really need it. Thanks for writing it!