### PR TITLE
Define final tabstop, after final function paren

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -160,7 +160,7 @@ func labelToProtocolSnippets(label string, kind source.CompletionItemKind, inser
 			}
 			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(strings.Trim(p, " ")))
 		}
-		b.WriteByte(')')
+		fmt.Fprintf(b, ")${0}")
 		return b.String(), false
 
 	}


### PR DESCRIPTION
From the `UltiSnips` doc:

> The '$0' tabstop is a special tabstop. It is always the last tabstop
> in the snippet no matter how many tabstops are defined.

Defining `$0` after the final paren allows the cursor to easily end up there after completing the rest of the tabstops.