### PR TITLE
Removed escaping "{" in parameter snippets to be LSP compliant

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -8,11 +8,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/saibing/bingo/langserver/internal/source"
 	"github.com/saibing/bingo/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
-	"sort"
-	"strings"
 )
 
 func (h *LangHandler) handleTextDocumentCompletion(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.CompletionParams) (*lsp.CompletionList, error) {
@@ -149,7 +150,6 @@ func labelToProtocolSnippets(label string, kind source.CompletionItemKind, inser
 		r := strings.NewReplacer(
 			`\`, `\\`,
 			`}`, `\}`,
-			`{`, `\{`,
 			`$`, `\$`,
 		)
 		b := bytes.NewBufferString(trimmed)


### PR DESCRIPTION
LSP defines only "}" as to be escaped, not the opening bracket:
https://microsoft.github.io/language-server-protocol/specification

Also the comment above the modified line states `{` should not be escaped.

Works fine in (neo)vim: ncm2/ncm2-vim-lsp#3

Not sure if it will break other editors/IDEs?