### PR TITLE
Removing type information from param snippets

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -8,11 +8,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/saibing/bingo/langserver/internal/source"
 	"github.com/saibing/bingo/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
-	"sort"
-	"strings"
 )
 
 func (h *LangHandler) handleTextDocumentCompletion(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.CompletionParams) (*lsp.CompletionList, error) {
@@ -158,7 +159,8 @@ func labelToProtocolSnippets(label string, kind source.CompletionItemKind, inser
 			if i != 0 {
 				b.WriteString(", ")
 			}
-			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(strings.Trim(p, " ")))
+			paramName := strings.Split(p, " ")[0]
+			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(strings.Trim(paramName, " ")))
 		}
 		fmt.Fprintf(b, ")${0}")
 		return b.String(), false


### PR DESCRIPTION
```go
// Before
findById(id int) // selected: id int
// After
findById(id) // selected: id
```
Instead of inserting the type information as well I think it's more convenient to just enter the parameter name. This has higher changes of no need to edit the inserted snippet text `id`  vs. definitely having to edit and remove the inserted snippet text `id int` as it's invalid code.