### PR TITLE
Bugfix (completion): first trimming params, then splitting on whitespaces

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -159,8 +159,8 @@ func labelToProtocolSnippets(label string, kind source.CompletionItemKind, inser
 			if i != 0 {
 				b.WriteString(", ")
 			}
-			paramName := strings.Split(p, " ")[0]
-			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(strings.Trim(paramName, " ")))
+			paramName := strings.Split(strings.Trim(p, " "), " ")[0]
+			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(paramName))
 		}
 		fmt.Fprintf(b, ")${0}")
 		return b.String(), false


### PR DESCRIPTION
In #75 I broke the snippet rendering for functions with more than 1 argument.

Before (missing identifier for second placeholder):
`Sscan(${1:str}, ${2:})${0}`
After:
`Sscan(${1:str}, ${2:a})${0}`

PR fixes broken rendering by flipping the order of trimming and splitting on whitespaces.
