### PR TITLE
Adds build tags support

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -51,6 +51,11 @@ type Config struct {
 	//
 	// Defaults to false
 	EnhanceSignatureHelp bool
+
+	// BuildTags controls build tag constraints and will be passed to build flags.
+	//
+	// Defaults to empty
+	BuildTags []string
 }
 
 // Apply sets the corresponding field in c for each non-nil field in o.

--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/saibing/bingo/langserver/internal/cache"
 	"github.com/saibing/bingo/langserver/internal/source"
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/jsonrpc2"
 )
 
@@ -72,8 +72,8 @@ type overlay struct {
 	diagnosticsStyle DiagnosticsStyleEnum
 }
 
-func newOverlay(conn *jsonrpc2.Conn, diagnosticsStyle DiagnosticsStyleEnum) *overlay {
-	return &overlay{conn: conn, view: cache.NewView(), diagnosticsStyle: diagnosticsStyle}
+func newOverlay(conn *jsonrpc2.Conn, diagnosticsStyle DiagnosticsStyleEnum, buildTags []string) *overlay {
+	return &overlay{conn: conn, view: cache.NewView(buildTags), diagnosticsStyle: diagnosticsStyle}
 }
 
 func (h *overlay) didOpen(ctx context.Context, params *lsp.DidOpenTextDocumentParams) {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/saibing/bingo/langserver/internal/cache"
-	"github.com/sourcegraph/go-lsp"
+	lsp "github.com/sourcegraph/go-lsp"
 	"github.com/sourcegraph/go-lsp/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 
@@ -83,7 +83,7 @@ func (h *LangHandler) doInit(ctx context.Context, conn *jsonrpc2.Conn, init *Ini
 	h.init = init
 	h.cancel = &cancel{}
 
-	h.overlay = newOverlay(conn, DiagnosticsStyleEnum(h.DefaultConfig.DiagnosticsStyle))
+	h.overlay = newOverlay(conn, DiagnosticsStyleEnum(h.DefaultConfig.DiagnosticsStyle), h.config.BuildTags)
 	h.project = cache.NewProject(conn, h.FilePath(init.Root()), h.overlay.view)
 	if err := h.project.Init(ctx, h.DefaultConfig.GolistDuration, h.DefaultConfig.GlobalCacheStyle); err != nil {
 		return err

--- a/langserver/internal/cache/view.go
+++ b/langserver/internal/cache/view.go
@@ -10,6 +10,7 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/saibing/bingo/langserver/internal/source"
@@ -29,13 +30,14 @@ type View struct {
 }
 
 // NewView create a new view
-func NewView() *View {
+func NewView(buildTags []string) *View {
 	return &View{
 		Config: &packages.Config{
-			Mode:    packages.LoadAllSyntax,
-			Fset:    token.NewFileSet(),
-			Tests:   true,
-			Overlay: make(map[string][]byte),
+			Mode:       packages.LoadAllSyntax,
+			Fset:       token.NewFileSet(),
+			Tests:      true,
+			Overlay:    make(map[string][]byte),
+			BuildFlags: []string{fmt.Sprintf("-tags='%s'", strings.Join(buildTags, " "))},
 		},
 		files:       make(map[source.URI]*File),
 		tempOverlay: make(map[string][]byte),

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/saibing/bingo/langserver"
@@ -35,6 +36,7 @@ var (
 	formatStyle          = flag.String("format-style", "goimports", "which format style is used to format documents. Supported: gofmt and goimports. Can be overridden by InitializationOptions.")
 	golistDuration       = flag.Int("golist-duration", 0, "the interval of refresh the go list cache, unit: second, 0 means that does not use go list cache. Can be overridden by InitializationOptions.")
 	enhanceSignatureHelp = flag.Bool("enhance-signature-help", false, "enhance signature help with return result. Can be overridden by InitializationOptions.")
+	buildTags            = flag.String("build-tags", "", "build tags, separated by spaces.")
 )
 
 // version is the version field we report back. If you are releasing a new version:
@@ -66,6 +68,7 @@ func main() {
 	cfg.FormatStyle = *formatStyle
 	cfg.GolistDuration = *golistDuration
 	cfg.EnhanceSignatureHelp = *enhanceSignatureHelp
+	cfg.BuildTags = strings.Split(*buildTags, " ")
 
 	if *maxparallelism > 0 {
 		cfg.MaxParallelism = *maxparallelism


### PR DESCRIPTION
- adds supports for `build tags`: https://github.com/saibing/bingo/issues/84
- this PR includes only CLI flag support for build tags. If this will be merged, I will make another changes that supports `InitializationOptions`.