### PR TITLE
Documentation: Move to README.md and update vscode-go settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,112 @@ bingo is a [Go](https://golang.org) language server that speaks
 This project was largely inspired by [go-langserver](https://github.com/sourcegraph/go-langserver),
 but bingo more simpler, more faster, more smarter!
 
-## Usage
+## Supported Features
+### Feature
+bingo will support editor features as follow:
 
+- [x] textDocument/hover
+- [x] textDocument/definition
+- [x] textDocument/xdefinition
+- [x] textDocument/typeDefinition
+- [x] textDocument/references
+- [x] textDocument/implementation
+- [x] textDocument/formatting
+- [x] textDocument/rangeFormatting
+- [x] textDocument/documentSymbol
+- [x] textDocument/completion
+- [x] textDocument/signatureHelp
+- [x] textDocument/publishDiagnostics
+- [x] textDocument/rename
+- [ ] textDocument/codeAction
+- [ ] textDocument/codeLens
+- [x] workspace/symbol
+- [x] workspace/xreferences
+
+## Install
+### Install
+bingo is a go module project, so you need install [Go 1.11 or above](https://golang.google.cn/dl/),
+to  install the `bingo`, please run
+
+```bash
+git clone https://github.com/saibing/bingo.git
+cd bingo
+GO111MODULE=on go install
+```
+If you live in China and may not be able to download golang.org/x/ dependency module, please set GOPROXY as follow:
+```bash
+ export GOPROXY=https://athens.azurefd.net/
+```
+
+### Usage
+How to use bingo with language client? Please reference [Language Client](https://github.com/saibing/bingo/wiki/Language-Client)
+
+## Configuration
+### bingo's flag
+#### --trace
+print all requests and responses
+#### --logfile &lt;path&gt;
+log both stdout and stderr to a file
+
+#### --format-style &lt;style&gt;
+which format style is used to format documents. Supported: gofmt and goimports
+
+#### --diagnostics-style &lt;style&gt;
+which diagnostics style is used to diagnostics current document. Supported: none, instant, onsave.
+
+####  --cache-style
+set global cache style: none, on-demand, always.
+
+## Language Client
+### [vscode-go](https://github.com/Microsoft/vscode-go)
+```json
+{
+    "go.useLanguageServer": true,
+    "go.alternateTools": {
+        "go-langserver": "bingo"
+    },
+    "go.languageServerFlags": [],
+    "go.languageServerExperimentalFeatures": {
+        "format": true,
+        "autoComplete": true
+    }
+}
+```
+
+### [coc.nvim](https://github.com/neoclide/coc.nvim)
+Please reference [Language server](https://github.com/neoclide/coc.nvim/wiki/Language-servers#go)
+
+### [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
+```vim
+let g:LanguageClient_rootMarkers = {
+        \ 'go': ['.git', 'go.mod'],
+        \ }
+
+let g:LanguageClient_serverCommands = {
+    \ 'go': ['bingo'],
+    \ }
+
+```
+
+## F.A.Q
+### Differences between go-langserver, bingo, golsp
+- [go-langserver](https://github.com/sourcegraph/go-langserver)
+
+> go-langserver is designed for online code reading such as github.com.
+
+- [bingo](https://github.com/saibing/bingo)
+
+> bingo is designed for offline editors such as vscode, vim, it focuses on code editing.
+
+- [gopls](https://github.com/golang/tools/blob/master/cmd/gopls/main.go)
+
+> gopls is an official language server,  and it is currently in early development.
+
+## Similar projects
+* [go-langserver](https://github.com/sourcegraph/go-langserver)
+* [gopls](https://github.com/golang/tools/blob/master/cmd/gopls/main.go)
+
+---
+
+## Usage
 Please reference bingo's [wiki](https://github.com/saibing/bingo/wiki).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ set global cache style: none, on-demand, always.
     "go.alternateTools": {
         "go-langserver": "bingo"
     },
-    "go.languageServerFlags": [],
+    "go.languageServerFlags": [
+        "-enhance-signature-help",
+        "-trace",
+        "-format-style=goimports",
+    ],
     "go.languageServerExperimentalFeatures": {
         "format": true,
         "autoComplete": true


### PR DESCRIPTION
* move instructions to `README.md`. Just makes things much easier.
* update `vscode-go` `go.languageServerFlags` settings example.

**NB:** Flags seem to indicate that `--format-style=<style>` is supported whilst I could only get this to work

```json
...
    "go.languageServerFlags": [
        "-enhance-signature-help",
        "-trace",
        "-format-style=goimports",
    ],
...
```