### PR TITLE
make build-tags option passed correctly

### DIFF
--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -96,7 +96,7 @@ type overlay struct {
 	diagnosticsStyle DiagnosticsStyleEnum
 }
 
-func newOverlay(ctx context.Context, conn *jsonrpc2.Conn, rootPath string, diagnosticsStyle DiagnosticsStyleEnum, buildTags []string) *overlay {
+func newOverlay(ctx context.Context, conn *jsonrpc2.Conn, rootPath string, diagnosticsStyle DiagnosticsStyleEnum, buildFlags []string) *overlay {
 	cfg := &packages.Config{
 		Context: ctx,
 		Dir:     rootPath,
@@ -106,8 +106,8 @@ func newOverlay(ctx context.Context, conn *jsonrpc2.Conn, rootPath string, diagn
 		ParseFile: func(fset *token.FileSet, filename string, src []byte) (*ast.File, error) {
 			return parser.ParseFile(fset, filename, src, parser.AllErrors|parser.ParseComments)
 		},
-		Tests: true,
-		BuildFlags: buildTags,
+		Tests:      true,
+		BuildFlags: buildFlags,
 	}
 	view := cache.NewView(cfg)
 	return &overlay{conn: conn, view: view, diagnosticsStyle: diagnosticsStyle}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -87,7 +87,11 @@ func (h *LangHandler) doInit(ctx context.Context, conn *jsonrpc2.Conn, init *Ini
 	h.cancel = &cancel{}
 
 	rootPath := h.FilePath(init.Root())
-	h.overlay = newOverlay(ctx, conn, rootPath, DiagnosticsStyleEnum(h.DefaultConfig.DiagnosticsStyle), h.config.BuildTags)
+	buildFlags := []string{}
+	if len(h.config.BuildTags) > 0 {
+		buildFlags = append(buildFlags, append([]string{"-tags"}, h.config.BuildTags...)...)
+	}
+	h.overlay = newOverlay(ctx, conn, rootPath, DiagnosticsStyleEnum(h.DefaultConfig.DiagnosticsStyle), buildFlags)
 	h.project = cache.NewProject(conn, rootPath, h.overlay.view)
 	if err := h.project.Init(ctx, h.DefaultConfig.GlobalCacheStyle); err != nil {
 		return err


### PR DESCRIPTION
Currently, `build-tags` option is passed as build flags incorrectly, this PR will fix this.