### PR TITLE
add BuildTags parameter to InitializationOptions

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -86,6 +86,10 @@ func (c Config) Apply(o *InitializationOptions) Config {
 		c.MaxParallelism = *o.MaxParallelism
 	}
 
+	if o.BuildTags != nil {
+		c.BuildTags = o.BuildTags
+	}
+
 	return c
 }
 

--- a/langserver/initialization.go
+++ b/langserver/initialization.go
@@ -1,6 +1,6 @@
 package langserver
 
-import "github.com/sourcegraph/go-lsp"
+import lsp "github.com/sourcegraph/go-lsp"
 
 // This file contains Go-specific extensions to LSP types.
 //
@@ -40,6 +40,9 @@ type InitializationOptions struct {
 
 	// MaxParallelism is an optional version of Config.MaxParallelism
 	MaxParallelism *int `json:"maxParallelism"`
+
+	// BuildTags is an optional version of Config.BuildTags
+	BuildTags []string `json:"buildTags"`
 }
 
 type InitializeParams struct {


### PR DESCRIPTION
- add BuildTags to InitializationOptions.
    - remaining task of #86.