### PR TITLE
Fix Hover for BuiltIn Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bingo
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/saibing/bingo)](https://goreportcard.com/report/github.com/saibing/bingo)
+
 bingo is a [Go](https://golang.org) language server that speaks
 [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 


### PR DESCRIPTION
We want `type error interface{Error() String}` to appear instead of `type builtin.error interface{Error() invalid type}`.

Not sure if I've broken anything, I'm going to test it further but a preliminary look would be good.

Fixes: https://github.com/saibing/bingo/issues/76

![Imgur](https://i.imgur.com/gWo2kgo.png)