### PR TITLE
textDocument/completion: set CompletionItem.Documentation

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -92,7 +92,8 @@ func toProtocolCompletionItems(candidates []source.CompletionItem, prefix string
 			// This is a hack so that the client sorts completion results in the order
 			// according to their score. This can be removed upon the resolution of
 			// https://github.com/Microsoft/language-server-protocol/issues/348.
-			SortText: fmt.Sprintf("%05d", i),
+			SortText:      fmt.Sprintf("%05d", i),
+			Documentation: candidate.Documentation,
 		}
 		// If we are completing a function, we should trigger signature help if possible.
 		//if triggerSignatureHelp && signatureHelpEnabled {

--- a/langserver/internal/source/hover.go
+++ b/langserver/internal/source/hover.go
@@ -1,0 +1,86 @@
+package source
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"github.com/saibing/bingo/langserver/internal/goast"
+	"golang.org/x/tools/go/packages"
+)
+
+func FindComments(pkg *packages.Package, o types.Object, name string) (string, error) {
+	if o == nil {
+		return "", nil
+	}
+
+	// Package names must be resolved specially, so do this now to avoid
+	// additional overhead.
+	if v, ok := o.(*types.PkgName); ok {
+		importPkg := goast.SearchImportPackage(pkg, v.Imported().Path())
+		if importPkg == nil {
+			return "", fmt.Errorf("failed to import package %q", v.Imported().Path())
+		}
+
+		return PackageDoc(importPkg.Syntax, name), nil
+	}
+
+	// Resolve the object o into its respective ast.Node
+	pathNodes, _, _ := goast.GetObjectPathNode(pkg, o)
+	if len(pathNodes) == 0 {
+		return "", nil
+	}
+
+	return PullComments(pathNodes), nil
+}
+
+func PullComments(pathNodes []ast.Node) string {
+	// Pull the comment out of the comment map for the file. Do
+	// not search too far away from the current path.
+	var comments string
+	for i := 0; i < 3 && i < len(pathNodes) && comments == ""; i++ {
+		switch v := pathNodes[i].(type) {
+		case *ast.Field:
+			// Concat associated documentation with any inline comments
+			comments = JoinCommentGroups(v.Doc, v.Comment)
+		case *ast.ValueSpec:
+			comments = v.Doc.Text()
+		case *ast.TypeSpec:
+			comments = v.Doc.Text()
+		case *ast.GenDecl:
+			comments = v.Doc.Text()
+		case *ast.FuncDecl:
+			comments = v.Doc.Text()
+		}
+	}
+	return comments
+}
+
+// PackageDoc finds the documentation for the named package from its files or
+// additional files.
+func PackageDoc(files []*ast.File, pkgName string) string {
+	for _, f := range files {
+		if f.Name.Name == pkgName {
+			txt := f.Doc.Text()
+			if strings.TrimSpace(txt) != "" {
+				return txt
+			}
+		}
+	}
+	return ""
+}
+
+// JoinCommentGroups joins the resultant non-empty comment text from two
+// CommentGroups with a newline.
+func JoinCommentGroups(a, b *ast.CommentGroup) string {
+	aText := a.Text()
+	bText := b.Text()
+	if aText == "" {
+		return bText
+	} else if bText == "" {
+		return aText
+	} else {
+		return aText + "\n" + bText
+	}
+}


### PR DESCRIPTION
**WIP:** Needs more work and input. I don't expect this PR to be approved, I guess I am just asking for input on how to improve the implementation

---

**Changes:**

* Remove `LangHandler:getImportPackage` and call `goast.SearchImportPackage` directly.
* Move `LangHandler:findComments` from `langserver/hover.go` to `langserver/internal/source/hover.go` as `FindComments`.
* Refactor `FindComments` and introduce new function `PullComments`.
* Move `packageDoc` from `langserver/hover.go` to `langserver/internal/source/hover.go`.
* Move `joinCommentGroups` from `langserver/hover.go` to `langserver/internal/source/hover.go`.

https://microsoft.github.io/language-server-protocol/specification#textDocument_completion

---

**Screenshot:**

![Imgur](https://i.imgur.com/jk72NwP.png)

---

See: https://github.com/saibing/bingo/issues/91