### PR TITLE
Fix handling of multiple build tags

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"golang.org/x/tools/imports"
@@ -89,7 +90,7 @@ func (h *LangHandler) doInit(ctx context.Context, conn *jsonrpc2.Conn, init *Ini
 	rootPath := h.FilePath(init.Root())
 	buildFlags := []string{}
 	if len(h.config.BuildTags) > 0 {
-		buildFlags = append(buildFlags, append([]string{"-tags"}, h.config.BuildTags...)...)
+		buildFlags = append(buildFlags, "-tags", strings.Join(h.config.BuildTags, " "))
 	}
 	h.project = cache.NewProject(ctx, conn, rootPath, buildFlags)
 	h.overlay = newOverlay(conn, h.project, DiagnosticsStyleEnum(h.DefaultConfig.DiagnosticsStyle))


### PR DESCRIPTION
Previously, each build tag was being passed to `go list` as a separate argument, which caused `go list` to interpret the second one as a package name, which it couldn't find. This meant that bingo only worked with zero or one build tags, not more than one.

Join the build tags with spaces and pass them all as a single argument to `go list`.