### PR TITLE
Add golangci-lint (https://github.com/golangci/golangci-lint) linter:

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+run:
+  tests: true
+
+linters:
+  enable-all: true
+  disable-all: false
+  fast: false
+
+# all available settings of specific linters
+linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: false
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: true
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: true
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  gocyclo:
+    min-complexity: 70
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 468
+
+  # see: https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml#L47
+  #
+  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  modules-download-mode: readonly
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: false
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SHELL:=/bin/sh
+
+.PHONY: devtools
+devtools:
+	@echo "\033[92m  ---> Installing golangci-lint (https://github.com/golangci/golangci-lint) ... \033[0m"
+	curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(shell go env GOPATH)/bin v1.12.5
+
+.PHONY: lint
+lint:
+	@echo "\033[92m  ---> Linting ... \033[0m"
+	golangci-lint run --config ./.golangci.yml ./...


### PR DESCRIPTION
* add `.golangci.yml` config file.
* add `Makefile`.
* add `make devtools` and `make lint` rules.

---

```sh
$ make lint                                       
  ---> Linting ... 
golangci-lint run --config ./.golangci.yml ./...
langserver/internal/source/completion.go:495:3: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/internal/source/completion.go:540:9: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/internal/source/hover.go:79:2: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/ast.go:157:3: caseOrder: case *ast.CommClause must go before the ast.Stmt case (gocritic)
langserver/hover.go:126:2: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/lsp_definition_test.go:122:2: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/lsp_workspace_symbol_test.go:165:3: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/lsp_xdefinition_test.go:96:2: ifElseChain: rewrite if-else to switch statement (gocritic)
langserver/internal/refs/refs.go:175:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
langserver/internal/refs/refs.go:351:4: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
langserver/handler.go:104:51: `conn` can be `github.com/sourcegraph/jsonrpc2.JSONRPC2` (interfacer)
langserver/internal/refs/refs.go:76:19: Using the variable on range scope `file` in function literal (scopelint)
langserver/internal/refs/refs.go:82:19: Using the variable on range scope `file` in function literal (scopelint)
langserver/internal/refs/refs.go:100:20: Using the variable on range scope `file` in function literal (scopelint)
langserver/symbol.go:373:61: Using a reference for the variable on range scope `sym` (scopelint)
langserver/lsp_references_test.go:96:2: Consider preallocating `results` (prealloc)
langserver/internal/source/completion.go:267:2: Consider preallocating `scopes` (prealloc)
langserver/internal/cache/cache.go:228:2: Consider preallocating `idList` (prealloc)
langserver/signature.go:58:2: Consider preallocating `result` (prealloc)
langserver/internal/cache/project.go:451:2: Consider preallocating `ranks` (prealloc)
langserver/internal/source/cache.go:11: File is not `gofmt`-ed with `-s` (gofmt)
langserver/internal/cache/observer.go:17: File is not `gofmt`-ed with `-s` (gofmt)
langserver/hover_test.go:15: File is not `gofmt`-ed with `-s` (gofmt)
langserver/internal/diff/diff.go:62: File is not `gofmt`-ed with `-s` (gofmt)
langserver/internal/diff/diff_test.go:22: File is not `gofmt`-ed with `-s` (gofmt)
langserver/lsp_completion_test.go:18:1: `completionContext` is a global variable (gochecknoglobals)
langserver/lsp_formatting_test.go:19:1: `formatContext` is a global variable (gochecknoglobals)
langserver/lsp_references_test.go:20:1: `referencesContext` is a global variable (gochecknoglobals)
langserver/lsp_hover_test.go:18:1: `hoverContext` is a global variable (gochecknoglobals)
langserver/lsp_implementations_test.go:21:1: `implementationContext` is a global variable (gochecknoglobals)
langserver/lsp_signature_test.go:18:1: `signatureContext` is a global variable (gochecknoglobals)
langserver/internal/util/util.go:86:1: `regDriveLetter` is a global variable (gochecknoglobals)
langserver/internal/source/completion.go:789:1: `builtinDetails` is a global variable (gochecknoglobals)
langserver/lsp_definition_test.go:20:1: `definitionContext` is a global variable (gochecknoglobals)
langserver/lsp_workspace_symbol_test.go:24:1: `workspaceSymbolContext` is a global variable (gochecknoglobals)
langserver/internal/cache/cache.go:70:1: `debugCache` is a global variable (gochecknoglobals)
langserver/internal/cache/check.go:329:1: `ioLimit` is a global variable (gochecknoglobals)
langserver/lsp_type_definition_test.go:18:1: `typeDefinitionContext` is a global variable (gochecknoglobals)
langserver/lsp_document_symbol_test.go:19:1: `symbolContext` is a global variable (gochecknoglobals)
main.go:22:1: `mode` is a global variable (gochecknoglobals)
langserver/lsp_workspace_references_test.go:22:1: `workspaceReferencesContext` is a global variable (gochecknoglobals)
langserver/lsp_renaming_test.go:19:1: `renameContext` is a global variable (gochecknoglobals)
langserver/lsp_test.go:45:1: `gopathDir` is a global variable (gochecknoglobals)
langserver/definition.go:44:1: `testOSToVFSPath` is a global variable (gochecknoglobals)
langserver/lsp_data_test.go:5:1: `testdata` is a global variable (gochecknoglobals)
langserver/lsp_xdefinition_test.go:19:1: `xDefinitionContext` is a global variable (gochecknoglobals)
langserver/internal/cache/project.go:35:1: `goroot` is a global variable (gochecknoglobals)
langserver/internal/cache/project.go:186:1: `siteLenMap` is a global variable (gochecknoglobals)
langserver/internal/cache/project.go:293:1: `defaultExcludeDir` is a global variable (gochecknoglobals)
langserver/symbol.go:108:1: `keywords` is a global variable (gochecknoglobals)
langserver/internal/cache/project.go:56:6: `isFileInsideGomod` is unused (deadcode)
langserver/hover.go:211:6: `commentsToText` is unused (deadcode)
langserver/hover.go:295:6: `packageForFile` is unused (deadcode)
langserver/hover.go:386:6: `fmtDocObject` is unused (deadcode)
langserver/fs.go:161:2: `noneDiagnostics` is unused (deadcode)
langserver/hover_test.go:14: line is 10680 characters (lll)
langserver/hover_test.go:30: line is 10819 characters (lll)
langserver/lsp_completion_test.go:49: line is 1123 characters (lll)
langserver/internal/source/analysis.go:100:13: struct of size 160 bytes could be of size 152 bytes (maligned)
langserver/internal/cache/module.go:15:17: struct of size 104 bytes could be of size 96 bytes (maligned)
langserver/config.go:9:13: struct of size 112 bytes could be of size 104 bytes (maligned)
langserver/position.go:49:26: unnecessary conversion (unconvert)
langserver/fs.go:185:42: unnecessary conversion (unconvert)
langserver/fs.go:193:18: unnecessary conversion (unconvert)
langserver/fs.go:206:16: unnecessary conversion (unconvert)
langserver/internal/source/analysis.go:109:2: `inputs` is unused (structcheck)
langserver/internal/source/analysis.go:113:2: `duration` is unused (structcheck)
langserver/internal/cache/gopath.go:10:2: `mu` is unused (structcheck)
langserver/ast.go:215:10: Error return value is not checked (errcheck)
langserver/definition.go:142:18: Error return value of `goast.GetObjectPathNode` is not checked (errcheck)
langserver/fs.go:123:14: Error return value of `h.setContent` is not checked (errcheck)
langserver/fs.go:142:14: Error return value of `h.setContent` is not checked (errcheck)
langserver/fs.go:176:17: Error return value of `h.conn.Notify` is not checked (errcheck)
langserver/handler_shared.go:30:2: Error return value of `p.overlay.conn.Notify` is not checked (errcheck)
langserver/handler_shared.go:35:2: Error return value of `p.overlay.conn.Notify` is not checked (errcheck)
langserver/handler_shared.go:40:2: Error return value of `p.overlay.conn.Notify` is not checked (errcheck)
langserver/hover.go:391:11: Error return value is not checked (errcheck)
langserver/hover.go:407:11: Error return value is not checked (errcheck)
langserver/implementation.go:31:13: Error return value of `goast.GetPathNodes` is not checked (errcheck)
langserver/internal/cache/check.go:51:14: Error return value of `v.Import` is not checked (errcheck)
langserver/internal/cache/check.go:127:10: Error return value of `parser.ParseFile` is not checked (errcheck)
langserver/internal/cache/check.go:260:13: Error return value of `check.Files` is not checked (errcheck)
langserver/internal/cache/project.go:166:12: Error return value of `(github.com/saibing/bingo/langserver/internal/source.URI).Filename` is not checked (errcheck)
langserver/internal/cache/project.go:338:12: Error return value of `(github.com/saibing/bingo/langserver/internal/source.URI).Filename` is not checked (errcheck)
langserver/internal/cache/project.go:400:24: Error return value of `p.gopath.rebuildCache` is not checked (errcheck)
langserver/internal/cache/project.go:428:2: Error return value of `p.conn.Notify` is not checked (errcheck)
langserver/internal/cache/project.go:433:2: Error return value of `p.conn.Notify` is not checked (errcheck)
langserver/internal/cache/project.go:438:2: Error return value of `p.conn.Notify` is not checked (errcheck)
langserver/internal/cache/project.go:498:12: Error return value of `uri.Filename` is not checked (errcheck)
langserver/internal/goast/path_node.go:139:9: Error return value of `GetPathNodes` is not checked (errcheck)
langserver/internal/refs/refs.go:170:10: Error return value is not checked (errcheck)
langserver/internal/source/completion.go:147:14: Error return value of `cache.Walk` is not checked (errcheck)
langserver/internal/source/completion.go:232:14: Error return value of `cache.Walk` is not checked (errcheck)
langserver/internal/source/completion.go:332:13: Error return value of `cache.Walk` is not checked (errcheck)
langserver/internal/source/hover.go:30:16: Error return value of `goast.GetObjectPathNode` is not checked (errcheck)
langserver/internal/source/signature_help.go:71:9: Error return value is not checked (errcheck)
langserver/internal/source/signature_help.go:76:10: Error return value is not checked (errcheck)
langserver/internal/source/uri.go:76:5: Error return value of `toFilename` is not checked (errcheck)
langserver/lsp_test.go:120:10: Error return value of `os.Chdir` is not checked (errcheck)
langserver/xcache.go:40:5: Error return value of `json.Marshal` is not checked (errcheck)
langserver/xcache.go:42:2: Error return value of `conn.Notify` is not checked (errcheck)
langserver/lsp_definition_test.go:135: 135-155 lines are duplicate of `langserver/lsp_type_definition_test.go:79-99` (dupl)
langserver/lsp_type_definition_test.go:79: 79-99 lines are duplicate of `langserver/lsp_definition_test.go:135-155` (dupl)
langserver/hover.go:142:5: ineffectual assignment to `extra` (ineffassign)
langserver/internal/util/util.go:78:6: func UriToPath should be URIToPath (golint)
langserver/internal/util/util.go:89:6: func UriToRealPath should be URIToRealPath (golint)
langserver/internal/cache/cache.go:16:6: type name will be used as cache.CacheStyle by other packages, and that stutters; consider calling this Style (golint)
langserver/internal/cache/project.go:222:21: error strings should not be capitalized or end with punctuation or a newline (golint)
langserver/handler_shared.go:29:1: receiver name p should be consistent with previous receiver name h for HandlerShared (golint)
langserver/handler_shared.go:34:1: receiver name p should be consistent with previous receiver name h for HandlerShared (golint)
langserver/handler_shared.go:39:1: receiver name p should be consistent with previous receiver name h for HandlerShared (golint)
langserver/handler_shared.go:43:1: receiver name p should be consistent with previous receiver name h for HandlerShared (golint)
langserver/lsp_completion_test.go:87:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_definition_test.go:98:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_document_symbol_test.go:135:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_formatting_test.go:52:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_hover_test.go:140:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_implementations_test.go:77:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_references_test.go:86:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_renaming_test.go:68:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_signature_test.go:63:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_type_definition_test.go:47:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_workspace_references_test.go:166:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_workspace_symbol_test.go:155:1: context.Context should be the first parameter of a function (golint)
langserver/lsp_xdefinition_test.go:81:1: context.Context should be the first parameter of a function (golint)
langserver/internal/diff/diff.go:154:7: don't use leading k in Go names; var kPrev should be prev (golint)
langserver/codeaction.go:13:61: `(*LangHandler).handleCodeAction` - `conn` is unused (unparam)
langserver/codeaction.go:14:2: `(*LangHandler).handleCodeAction` - `req` is unused (unparam)
langserver/completion.go:19:73: `(*LangHandler).handleTextDocumentCompletion` - `conn` is unused (unparam)
langserver/definition.go:61:88: `(*LangHandler).doHandleXDefinition` - `req` is unused (unparam)
langserver/definition.go:104:45: `(*LangHandler).lookupIdentDefinition` - `ctx` is unused (unparam)
langserver/format.go:23:73: `(*LangHandler).handleTextDocumentFormatting` - `conn` is unused (unparam)
langserver/format.go:27:78: `(*LangHandler).handleTextDocumentRangeFormatting` - `conn` is unused (unparam)
langserver/fs.go:213:24: `newJsonrpc2Errorf` - `code` always receives `jsonrpc2.CodeInternalError` (`-32603`) (unparam)
langserver/hover.go:27:56: `(*LangHandler).handleHover` - `conn` is unused (unparam)
langserver/hover.go:78:78: `(*LangHandler).hoverBasicLit` - `basicLit` is unused (unparam)
langserver/hover.go:96:57: `(*LangHandler).hoverIdent` - `pathNodes` is unused (unparam)
langserver/hover.go:189:27: `packageStatementName` - `fset` is unused (unparam)
langserver/implementation.go:19:77: `(*LangHandler).handleTextDocumentImplementation` - `conn` is unused (unparam)
langserver/internal/source/completion.go:205:38: `selector` - `pos` is unused (unparam)
langserver/internal/source/completion.go:616:41: `enclosingFunction` - `pos` is unused (unparam)
langserver/loader.go:50:59: `(*LangHandler).getPosFromFile` - `pkg` is unused (unparam)
langserver/references.go:27:75: `(*LangHandler).doHandleTextDocumentReferences` - `conn` is unused (unparam)
langserver/signature.go:12:76: `(*LangHandler).handleTextDocumentSignatureHelp` - `conn` is unused (unparam)
langserver/symbol.go:275:69: `(*LangHandler).handleTextDocumentSymbol` - `conn` is unused (unparam)
langserver/symbol.go:312:57: `(*LangHandler).handleSymbol` - `conn` is unused (unparam)
langserver/workspace_refs.go:26:94: `(*LangHandler).handleWorkspaceReferences` - `req` is unused (unparam)
langserver/workspace_refs.go:91:65: `(*LangHandler).workspaceRefsFromPkg` - `conn` is unused (unparam)
langserver/internal/source/completion.go:113:4: empty branch (megacheck)
langserver/internal/cache/project.go:391:9: should use time.Since instead of time.Now().Sub (megacheck)
langserver/internal/diff/diff.go:50:4: should replace loop with b = append(b, a[prevI2:op.I1]...) (megacheck)
langserver/internal/goast/path_node.go:25:10: should omit nil check; len() for nil slices is defined as zero (megacheck)
langserver/internal/refs/refs.go:284:2: should merge variable declaration with assignment on next line (megacheck)
langserver/symbol.go:426:2: redundant return statement (megacheck)
langserver/workspace_refs.go:138:2: should write defPkg := pkg.Imports[def.ImportPath] instead of defPkg, _ := pkg.Imports[def.ImportPath] (megacheck)
langserver/workspace_refs.go:163:13: the argument is already a string, there's no need to use fmt.Sprintf (megacheck)
langserver/hover.go:307:6: func `inRange` is unused (megacheck)
langserver/hover.go:316:6: func `findDocTarget` is unused (megacheck)
langserver/hover.go:459:6: func `typeName` is unused (megacheck)
langserver/hover.go:471:6: func `fmtNode` is unused (megacheck)
langserver/hover.go:481:6: type `byDistance` is unused (megacheck)
langserver/hover.go:496:6: func `abs` is unused (megacheck)
langserver/internal/cache/cache.go:163:23: func `(*GlobalCache).clean` is unused (megacheck)
langserver/internal/diff/diff_test.go:15:3: field `lines` is unused (megacheck)
langserver/internal/source/analysis.go:40:25: func `(*AnalysisCache).analyze` is unused (megacheck)
langserver/internal/source/analysis.go:101:2: field `once` is unused (megacheck)
langserver/internal/source/analysis.go:104:2: field `pass` is unused (megacheck)
langserver/internal/source/analysis.go:105:2: field `isroot` is unused (megacheck)
langserver/internal/source/analysis.go:106:2: field `deps` is unused (megacheck)
langserver/internal/source/analysis.go:107:2: field `objectFacts` is unused (megacheck)
langserver/internal/source/analysis.go:108:2: field `packageFacts` is unused (megacheck)
langserver/internal/source/analysis.go:110:2: field `result` is unused (megacheck)
langserver/internal/source/analysis.go:111:2: field `diagnostics` is unused (megacheck)
langserver/internal/source/analysis.go:112:2: field `err` is unused (megacheck)
langserver/internal/source/analysis.go:116:6: type `objectFactKey` is unused (megacheck)
langserver/internal/source/analysis.go:121:6: type `packageFactKey` is unused (megacheck)
langserver/internal/source/analysis.go:130:6: func `execAll` is unused (megacheck)
langserver/internal/source/analysis.go:143:20: func `(*action).exec` is unused (megacheck)
langserver/internal/source/analysis.go:145:20: func `(*action).execOnce` is unused (megacheck)
langserver/internal/source/analysis.go:222:6: func `inheritFacts` is unused (megacheck)
langserver/internal/source/analysis.go:250:6: func `exportedFrom` is unused (megacheck)
langserver/internal/source/analysis.go:267:20: func `(*action).importObjectFact` is unused (megacheck)
langserver/internal/source/analysis.go:280:20: func `(*action).exportObjectFact` is unused (megacheck)
langserver/internal/source/analysis.go:297:20: func `(*action).importPackageFact` is unused (megacheck)
langserver/internal/source/analysis.go:310:20: func `(*action).exportPackageFact` is unused (megacheck)
langserver/internal/source/analysis.go:319:6: func `factType` is unused (megacheck)
langserver/xcache.go:15:23: func `(*LangHandler).cacheGet` is unused (megacheck)
langserver/xcache.go:35:23: func `(*LangHandler).cacheSet` is unused (megacheck)
langserver/internal/util/util.go:5: File is not `goimports`-ed (goimports)
langserver/internal/source/uri.go:11: File is not `goimports`-ed (goimports)
langserver/internal/protocol/language.go:4: File is not `goimports`-ed (goimports)
langserver/ast.go:5: File is not `goimports`-ed (goimports)
langserver/codeaction.go:9: File is not `goimports`-ed (goimports)
langserver/completion.go:15: File is not `goimports`-ed (goimports)
langserver/definition.go:12: File is not `goimports`-ed (goimports)
langserver/diagnostics.go:15: File is not `goimports`-ed (goimports)
langserver/format.go:15: File is not `goimports`-ed (goimports)
langserver/handler_shared.go:11: File is not `goimports`-ed (goimports)
langserver/hover.go:23: File is not `goimports`-ed (goimports)
langserver/implementation.go:6: File is not `goimports`-ed (goimports)
langserver/loader.go:15: File is not `goimports`-ed (goimports)
langserver/position.go:12: File is not `goimports`-ed (goimports)
langserver/references.go:7: File is not `goimports`-ed (goimports)
langserver/rename.go:6: File is not `goimports`-ed (goimports)
langserver/signature.go:8: File is not `goimports`-ed (goimports)
langserver/symbol.go:17: File is not `goimports`-ed (goimports)
langserver/symbol_descriptor.go:4: File is not `goimports`-ed (goimports)
langserver/workspace_refs.go:13: File is not `goimports`-ed (goimports)
langserver/hover_test.go:6: File is not `goimports`-ed (goimports)
langserver/lsp_completion_test.go:11: File is not `goimports`-ed (goimports)
langserver/lsp_definition_test.go:16: File is not `goimports`-ed (goimports)
langserver/lsp_document_symbol_test.go:12: File is not `goimports`-ed (goimports)
langserver/lsp_formatting_test.go:12: File is not `goimports`-ed (goimports)
langserver/lsp_hover_test.go:14: File is not `goimports`-ed (goimports)
langserver/lsp_implementations_test.go:13: File is not `goimports`-ed (goimports)
langserver/lsp_references_test.go:16: File is not `goimports`-ed (goimports)
langserver/lsp_renaming_test.go:12: File is not `goimports`-ed (goimports)
langserver/lsp_signature_test.go:11: File is not `goimports`-ed (goimports)
langserver/lsp_test.go:23: File is not `goimports`-ed (goimports)
langserver/lsp_type_definition_test.go:14: File is not `goimports`-ed (goimports)
langserver/lsp_workspace_references_test.go:19: File is not `goimports`-ed (goimports)
langserver/lsp_workspace_symbol_test.go:17: File is not `goimports`-ed (goimports)
langserver/lsp_xdefinition_test.go:14: File is not `goimports`-ed (goimports)
langserver/symbol_test.go:8: File is not `goimports`-ed (goimports)
make: *** [lint] Error 1
```