### PR TITLE
fixed bug in code formatting

### DIFF
--- a/langserver/format.go
+++ b/langserver/format.go
@@ -9,6 +9,7 @@ package langserver
 import (
 	"context"
 	"fmt"
+
 	"github.com/saibing/bingo/langserver/internal/source"
 	"github.com/saibing/bingo/langserver/internal/span"
 	"github.com/sourcegraph/go-lsp"
@@ -66,22 +67,10 @@ func toProtocolEdits(ctx context.Context, f source.File, edits []source.TextEdit
 		return []lsp.TextEdit{}
 	}
 
-	content := f.GetContent(ctx)
-	// When a file ends with an empty line, the newline character is counted
-	// as part of the previous line. This causes the formatter to insert
-	// another unnecessary newline on each formatting. We handle this case by
-	// checking if the file already ends with a newline character.
-	hasExtraNewline := content[len(content)-1] == '\n'
 	result := make([]lsp.TextEdit, len(edits))
 	for i, edit := range edits {
-		rng := toProtocolRange(edit.Span)
-		// If the edit ends at the end of the file, add the extra line.
-		if hasExtraNewline && edit.Span.End().Offset() == len(content) {
-			rng.End.Line++
-			rng.End.Character = 0
-		}
 		result[i] = lsp.TextEdit{
-			Range:   rng,
+			Range:   toProtocolRange(edit.Span),
 			NewText: edit.NewText,
 		}
 	}

--- a/langserver/position.go
+++ b/langserver/position.go
@@ -55,8 +55,8 @@ func fromProtocolPosition(f *token.File, pos lsp.Position) token.Pos {
 // It requires the token file the pos belongs to in order to do this.
 func toProtocolPosition(point span.Point) lsp.Position {
 	return lsp.Position{
-		Line:      point.Line(),
-		Character: point.Column(),
+		Line:      point.Line() - 1,
+		Character: point.Column() - 1,
 	}
 }
 


### PR DESCRIPTION
There are two problems in code formatting:

1. According to currently `gopls`'s internal implementation, end point's offset  is always `-1`, which makes the `Offset()` panic.  Actually, as I tested in my neovim environment, checking file's ending is unnecessary now, so I removed these logic, and it works fine for me.

2. `internal/source`'s line and column number always starts from `1`, so we should correct it first. Otherwise code formatting cannot work properly.

@saibing PTAL