### PR TITLE
Format anonymous struct issue 143

### DIFF
--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -25,22 +25,22 @@ func (h *HandlerShared) FilePath(uri lsp.DocumentURI) string {
 	return util.GetRealPath(path)
 }
 
-func (p *HandlerShared) notifyError(message string) {
-	_ = p.overlay.conn.Notify(context.Background(), "window/showMessage", &lsp.ShowMessageParams{Type: lsp.MTError, Message: message})
+func (h *HandlerShared) notifyError(message string) {
+	_ = h.overlay.conn.Notify(context.Background(), "window/showMessage", &lsp.ShowMessageParams{Type: lsp.MTError, Message: message})
 }
 
 // NotifyInfo notify info to lsp client
-func (p *HandlerShared) notifyInfo(message string) {
-	_ = p.overlay.conn.Notify(context.Background(), "window/showMessage", &lsp.ShowMessageParams{Type: lsp.Info, Message: message})
+func (h *HandlerShared) notifyInfo(message string) {
+	_ = h.overlay.conn.Notify(context.Background(), "window/showMessage", &lsp.ShowMessageParams{Type: lsp.Info, Message: message})
 }
 
 // NotifyLog notify log to lsp client
-func (p *HandlerShared) notifyLog(message string) {
-	_ = p.overlay.conn.Notify(context.Background(), "window/logMessage", &lsp.LogMessageParams{Type: lsp.Info, Message: message})
+func (h *HandlerShared) notifyLog(message string) {
+	_ = h.overlay.conn.Notify(context.Background(), "window/logMessage", &lsp.LogMessageParams{Type: lsp.Info, Message: message})
 }
 
-func (p *HandlerShared) View() source.View {
-	return p.overlay.view()
+func (h *HandlerShared) View() source.View {
+	return h.overlay.view()
 }
 
 func (h *HandlerShared) getFindPackageFunc() cache.FindPackageFunc {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -145,7 +145,8 @@ func (h *LangHandler) hoverIdent(pkg source.Package, pathNodes []ast.Node, ident
 			}
 		}
 		if s == "" {
-			s = types.ObjectString(o, qf)
+			objectString := types.ObjectString(o, qf)
+			s = prettyPrintTypesString(objectString)
 		}
 
 	} else if t != nil {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -12,9 +12,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/saibing/bingo/langserver/internal/source"
 	doc "github.com/slimsag/godocmd"
 
+	"github.com/saibing/bingo/langserver/internal/source"
 	"github.com/saibing/bingo/langserver/internal/util"
 
 	"github.com/sourcegraph/go-lsp"
@@ -143,7 +143,10 @@ func (h *LangHandler) hoverIdent(pkg source.Package, pathNodes []ast.Node, ident
 					extra = prettyPrintTypesString(builtInObject.String())
 				}
 			}
+		} else if _, ok := o.(*types.PkgName); ok {
+			s = types.ObjectString(o, qf)
 		}
+
 		if s == "" {
 			objectString := types.ObjectString(o, qf)
 			s = prettyPrintTypesString(objectString)

--- a/langserver/hover_test.go
+++ b/langserver/hover_test.go
@@ -66,7 +66,6 @@ func TestPrettyprintTypesString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-
 		actual := prettyPrintTypesString(testCase.input)
 		require.Equal(testCase.expected, actual)
 	}

--- a/langserver/lsp_hover_test.go
+++ b/langserver/lsp_hover_test.go
@@ -23,6 +23,7 @@ func TestHover(t *testing.T) {
 	hoverContext.setup(t)
 
 	test := func(t *testing.T, input string, output string) {
+		t.Helper()
 		testHover(t, &hoverTestCase{input: input, output: output})
 	}
 
@@ -128,7 +129,10 @@ type hoverTestCase struct {
 }
 
 func testHover(tb testing.TB, c *hoverTestCase) {
+	tb.Helper()
 	tbRun(tb, fmt.Sprintf("hover-%s", strings.Replace(c.input, "/", "-", -1)), func(t testing.TB) {
+		t.Helper()
+
 		dir, err := filepath.Abs(hoverContext.root())
 		if err != nil {
 			log.Fatal("testHover", err)
@@ -138,6 +142,7 @@ func testHover(tb testing.TB, c *hoverTestCase) {
 }
 
 func doHoverTest(t testing.TB, ctx context.Context, conn *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos, want string) {
+	t.Helper()
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)

--- a/langserver/lsp_test.go
+++ b/langserver/lsp_test.go
@@ -92,6 +92,7 @@ func newTestContext(style cache.CacheStyle) *TestContext {
 }
 
 func (tx *TestContext) setup(t *testing.T) {
+	t.Helper()
 	tx.exported = packagestest.Export(t, packagestest.Modules, testdata)
 	tx.initServer(t)
 }
@@ -120,6 +121,7 @@ func (tx *TestContext) root() string {
 }
 
 func (tx *TestContext) initServer(t *testing.T) {
+	t.Helper()
 	rootDir := tx.root()
 	os.Chdir(rootDir)
 	root := util.PathToURI(filepath.ToSlash(rootDir))
@@ -147,11 +149,18 @@ func (tx *TestContext) initServer(t *testing.T) {
 
 // tbRun calls (testing.T).Run or (testing.B).Run.
 func tbRun(t testing.TB, name string, f func(testing.TB)) bool {
+	t.Helper()
 	switch tb := t.(type) {
 	case *testing.B:
-		return tb.Run(name, func(b *testing.B) { f(b) })
+		return tb.Run(name, func(b *testing.B) {
+			b.Helper()
+			f(b)
+		})
 	case *testing.T:
-		return tb.Run(name, func(t *testing.T) { f(t) })
+		return tb.Run(name, func(t *testing.T) {
+			t.Helper()
+			f(t)
+		})
 	default:
 		panic(fmt.Sprintf("unexpected %T, want *testing.B or *testing.T", tb))
 	}


### PR DESCRIPTION
Format anonymous struct in `hoverIdent` in `langserver/hover.go`:
* Call `prettyPrintTypesString` with the result of `types.ObjectString(o, qf)`.
* If we are hovering over `*types.PkgName` call `go/types.ObjectString`
instead of `prettyPrintTypesString`.
* Misc formatting of code.

tests `langserver/lsp_hover_test.go` and `langserver/lsp_test.go`: call `t.Helper()`

* Call `t.Helper()` in the test helpers methods so that when tests fail
the actual place is printed instead of the helper method.

Issue: https://github.com/saibing/bingo/issues/143
