### PR TITLE
Remove `maxparallelism` flag and `MaxParallelism` from `InitializationOptions`

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -1,9 +1,5 @@
 package langserver
 
-import (
-	"runtime"
-)
-
 // Config adjusts the behaviour of go-langserver. Please keep in sync with
 // InitializationOptions in the README.
 type Config struct {
@@ -33,14 +29,6 @@ type Config struct {
 	//
 	// Defaults to empty string if not specified.
 	GoimportsLocalPrefix string
-
-	// MaxParallelism controls the maximum number of goroutines that should be used
-	// to fulfill requests. This is useful in editor environments where users do
-	// not want results ASAP, but rather just semi quickly without eating all of
-	// their CPU.
-	//
-	// Defaults to half of your CPU cores if not specified.
-	MaxParallelism int
 
 	// EnhanceSignatureHelp enhance the signature help with return result.
 	//
@@ -82,10 +70,6 @@ func (c Config) Apply(o *InitializationOptions) Config {
 		c.GoimportsLocalPrefix = *o.GoimportsLocalPrefix
 	}
 
-	if o.MaxParallelism != nil {
-		c.MaxParallelism = *o.MaxParallelism
-	}
-
 	if o.BuildTags != nil {
 		c.BuildTags = o.BuildTags
 	}
@@ -96,14 +80,7 @@ func (c Config) Apply(o *InitializationOptions) Config {
 // NewDefaultConfig returns the default config. See the field comments for the
 // defaults.
 func NewDefaultConfig() Config {
-	// Default max parallelism to half the CPU cores, but at least always one.
-	maxparallelism := runtime.NumCPU() / 2
-	if maxparallelism <= 0 {
-		maxparallelism = 1
-	}
-
 	return Config{
 		DisableFuncSnippet: false,
-		MaxParallelism:     maxparallelism,
 	}
 }

--- a/langserver/initialization.go
+++ b/langserver/initialization.go
@@ -38,9 +38,6 @@ type InitializationOptions struct {
 	// Config.GoimportsLocalPrefix
 	GoimportsLocalPrefix *string `json:"goimportsLocalPrefix"`
 
-	// MaxParallelism is an optional version of Config.MaxParallelism
-	MaxParallelism *int `json:"maxParallelism"`
-
 	// BuildTags is an optional version of Config.BuildTags
 	BuildTags []string `json:"buildTags"`
 }

--- a/langserver/lsp_test.go
+++ b/langserver/lsp_test.go
@@ -31,6 +31,12 @@ const (
 	rootImportPath = "github.com/saibing/bingo/langserver/test/pkg"
 )
 
+var (
+	gopathDir    = getGOPATH()
+	githubModule = "pkg/mod/github.com/saibing/dep@v1.0.2"
+	gomoduleDir  = filepath.Join(gopathDir, githubModule)
+)
+
 func getGOPATH() string {
 	gopath := os.Getenv("GOPATH")
 	if gopath == "" {
@@ -40,12 +46,6 @@ func getGOPATH() string {
 	paths := strings.Split(gopath, string(os.PathListSeparator))
 	return paths[0]
 }
-
-var (
-	gopathDir    = getGOPATH()
-	githubModule = "pkg/mod/github.com/saibing/dep@v1.0.2"
-	gomoduleDir  = filepath.Join(gopathDir, githubModule)
-)
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -124,8 +124,8 @@ func (tx *TestContext) initServer(t *testing.T) {
 	t.Helper()
 	rootDir := tx.root()
 	os.Chdir(rootDir)
-	root := util.PathToURI(filepath.ToSlash(rootDir))
-	t.Log("rootUri:", root)
+	rootURI := util.PathToURI(filepath.ToSlash(rootDir))
+	t.Logf("rootUri:=%q", rootURI)
 
 	// Prepare the connection.
 	client, server := net.Pipe()
@@ -136,7 +136,7 @@ func (tx *TestContext) initServer(t *testing.T) {
 	tdCap.Completion.CompletionItemKind.ValueSet = []lsp.CompletionItemKind{lsp.CIKConstant}
 	params := InitializeParams{
 		InitializeParams: lsp.InitializeParams{
-			RootURI:      root,
+			RootURI:      rootURI,
 			Capabilities: lsp.ClientCapabilities{TextDocument: tdCap},
 		},
 

--- a/main.go
+++ b/main.go
@@ -13,8 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/saibing/bingo/langserver"
 	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/saibing/bingo/langserver"
 
 	_ "net/http/pprof"
 )
@@ -29,7 +30,6 @@ var (
 	pprof        = flag.String("pprof", "", "start a pprof http server (https://golang.org/pkg/net/http/pprof/)")
 
 	// Default Config, can be overridden by InitializationOptions
-	maxparallelism       = flag.Int("maxparallelism", 0, "use at max N parallel goroutines to fulfill requests. Can be overridden by InitializationOptions.")
 	diagnosticsStyle     = flag.String("diagnostics-style", "instant", "diagnostics style: none, instant, onsave. Can be overridden by InitializationOptions.")
 	disableFuncSnippet   = flag.Bool("disable-func-snippet", false, "disable argument snippets on func completion. Can be overridden by InitializationOptions.")
 	globalCacheStyle     = flag.String("cache-style", "always", "set global cache style: none, on-demand, always. Can be overridden by InitializationOptions.")
@@ -78,10 +78,6 @@ func main() {
 
 	if *buildTags != "" {
 		cfg.BuildTags = strings.Split(*buildTags, " ")
-	}
-
-	if *maxparallelism > 0 {
-		cfg.MaxParallelism = *maxparallelism
 	}
 
 	if err := run(cfg); err != nil {


### PR DESCRIPTION
Remove `maxparallelism` flag and `MaxParallelism` from `InitializationOptions`

Misc:
* `langserver/lsp_test.go`: Move `var` block to top of the file.
* Other non-risky code cleanup.